### PR TITLE
[Init] MoyaWrapper Error handling 구현

### DIFF
--- a/Projects/Data/Sources/DataSource/HomeDataSource.swift
+++ b/Projects/Data/Sources/DataSource/HomeDataSource.swift
@@ -10,9 +10,10 @@ import Foundation
 import Combine
 import CombineMoya
 import Moya
+import Domain
 
 public protocol HomeDataSource {
-    func loadMaxim() -> AnyPublisher<SlipDTO, Error>
+    func loadMaxim() -> AnyPublisher<SlipDTO, NetworkErrorDTO>
 }
 
 public class DefaultHomeDataSource: HomeDataSource {
@@ -21,8 +22,9 @@ public class DefaultHomeDataSource: HomeDataSource {
     
     private let moyaProvider = MoyaWrapper<APIService>()
     
-    public func loadMaxim() -> AnyPublisher<SlipDTO, Error> {
+    public func loadMaxim() -> AnyPublisher<SlipDTO, NetworkErrorDTO> {
         return moyaProvider.call(target: .oneSlip)
+            .eraseToAnyPublisher()
     }
     
 }

--- a/Projects/Data/Sources/DataSource/HomeDataSource.swift
+++ b/Projects/Data/Sources/DataSource/HomeDataSource.swift
@@ -10,7 +10,6 @@ import Foundation
 import Combine
 import CombineMoya
 import Moya
-import Domain
 
 public protocol HomeDataSource {
     func loadMaxim() -> AnyPublisher<SlipDTO, NetworkErrorDTO>

--- a/Projects/Data/Sources/Network/APIService.swift
+++ b/Projects/Data/Sources/Network/APIService.swift
@@ -16,14 +16,14 @@ extension APIService: TargetType {
     var baseURL: URL {
         switch self {
         case .oneSlip:
-            return URL(string: "https://api.adviceslip.com/advice")!
+            return URL(string: "https://api.adviceslip.com/")!
         }
     }
     
     var path: String {
         switch self {
         case .oneSlip:
-            return ""
+            return "advice"
         }
     }
     

--- a/Projects/Data/Sources/Network/MoyaWrapper.swift
+++ b/Projects/Data/Sources/Network/MoyaWrapper.swift
@@ -8,18 +8,50 @@
 
 import Foundation
 import Combine
+import Domain
 import Moya
 import CombineMoya
 
 class MoyaWrapper<Provider: TargetType>: MoyaProvider<Provider> {
     
-    func call<Value>(target: Provider) -> AnyPublisher<Value, Error> where Value: Decodable {
+    func call<Value>(target: Provider) -> AnyPublisher<Value, NetworkErrorDTO> where Value: Decodable {
         return self.requestPublisher(target)
             .map(Value.self)
-            .mapError { error -> Error in
-                return error
+            .mapError { error -> NetworkErrorDTO in
+                return self.mapNetworkError(error: error)
             }
             .eraseToAnyPublisher()
+    }
+    
+}
+
+extension MoyaWrapper {
+    
+    private func mapNetworkError(error: MoyaError) -> NetworkErrorDTO {
+        switch error {
+            // Encoding Error
+        case .encodableMapping(let error):
+            return NetworkErrorDTO.encodeError(error)
+        case .parameterEncoding(let error):
+            return NetworkErrorDTO.encodeError(error)
+            // Mapping Error
+        case .imageMapping(let response):
+            return NetworkErrorDTO.mappingError(response)
+        case .jsonMapping(let response):
+            return NetworkErrorDTO.mappingError(response)
+        case .objectMapping(_, let response):
+            return NetworkErrorDTO.mappingError(response)
+        case .stringMapping(let response):
+            return NetworkErrorDTO.mappingError(response)
+        case .requestMapping(let string):
+            return NetworkErrorDTO.requestError(string)
+            // Underlying Error
+        case .underlying(let error, let response):
+            return NetworkErrorDTO.underlyingError(error, response)
+            // StatusCode Error
+        case .statusCode(let response):
+            return NetworkErrorDTO.statusCode(response)
+        }
     }
     
 }

--- a/Projects/Data/Sources/Network/MoyaWrapper.swift
+++ b/Projects/Data/Sources/Network/MoyaWrapper.swift
@@ -17,18 +17,18 @@ class MoyaWrapper<Provider: TargetType>: MoyaProvider<Provider> {
     func call<Value>(target: Provider) -> AnyPublisher<Value, NetworkErrorDTO> where Value: Decodable {
         return self.requestPublisher(target)
             .map(Value.self)
-            .mapError { error -> NetworkErrorDTO in
-                return self.mapNetworkError(error: error)
+            .mapError { moyaError -> NetworkErrorDTO in
+                return moyaError.toNetworkError()
             }
             .eraseToAnyPublisher()
     }
     
 }
 
-extension MoyaWrapper {
+extension MoyaError {
     
-    private func mapNetworkError(error: MoyaError) -> NetworkErrorDTO {
-        switch error {
+    public func toNetworkError() -> NetworkErrorDTO {
+        switch self {
             // Encoding Error
         case .encodableMapping(let error):
             return NetworkErrorDTO.encodeError(error)

--- a/Projects/Data/Sources/Network/NetworkErrorDTO.swift
+++ b/Projects/Data/Sources/Network/NetworkErrorDTO.swift
@@ -1,0 +1,62 @@
+//
+//  NetworkError.swift
+//  Data
+//
+//  Created by Lee Myeonghwan on 2023/06/29.
+//  Copyright © 2023 Lito. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Moya
+
+public enum NetworkErrorDTO: Error {
+    
+    case encodeError(Error)
+    case mappingError(Response)
+    case requestError(String)
+    case statusCode(Response)
+    case underlyingError(Error, Response?)
+    
+    // TODO: 서버와 협의하여 Error string 구성
+    public var debugString: String {
+        switch self {
+        case .encodeError(let error):
+            return "⛑️ Encode Error: \(error.localizedDescription) "
+        case .mappingError(let response):
+            return "⛑️ Mapping Error: \(response.description)"
+        case .requestError(let description):
+            return "⛑️ Request Error \(description)"
+        case .statusCode(let response):
+            return "⛑️ StatuCode Error \(response.statusCode)"
+        case .underlyingError(let error, let response):
+            return "⛑️ UnderlyingError \(error.localizedDescription) \n response: \(String(describing: response))"
+        }
+    }
+    
+    public func toVO() -> NetworkErrorVO {
+        // TODO: 상황에 맞게 지속적으로 Error handling 업데이트 필요
+        switch self {
+        case .encodeError(_):
+            return .fatalError
+        case .mappingError(_):
+            return .fatalError
+        case .requestError(_):
+            return .fatalError
+        case .statusCode(let response):
+            if 500...599 ~= response.statusCode {
+                return .retryableError
+            }
+            if 429 == response.statusCode {
+                return .retryableError
+            }
+            if 429 == response.statusCode {
+                return .retryableError
+            }
+            return .fatalError
+        case .underlyingError(_, _):
+            return .fatalError
+        }
+    }
+    
+}

--- a/Projects/Domain/Sources/RepositoryProtocol/HomeRepository.swift
+++ b/Projects/Domain/Sources/RepositoryProtocol/HomeRepository.swift
@@ -9,5 +9,5 @@
 import Combine
 
 public protocol HomeRepository {
-    func loadSlip() -> AnyPublisher<SlipVO, Error>
+    func loadSlip() -> AnyPublisher<SlipVO, NetworkErrorVO>
 }

--- a/Projects/Domain/Sources/Services/HomeUseCase.swift
+++ b/Projects/Domain/Sources/Services/HomeUseCase.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 
 public protocol HomeUseCase {
-    func load() -> AnyPublisher<SlipVO, Error>
+    func load() -> AnyPublisher<SlipVO, NetworkErrorVO>
 }
 
 public final class DefaultHomeUseCase: HomeUseCase {
@@ -13,7 +13,7 @@ public final class DefaultHomeUseCase: HomeUseCase {
         self.repository = repository
     }
     
-    public func load() -> AnyPublisher<SlipVO, Error>{
+    public func load() -> AnyPublisher<SlipVO, NetworkErrorVO>{
         return repository.loadSlip()
     }
 }
@@ -23,9 +23,9 @@ public final class StubHomeUseCase: HomeUseCase {
     
     public init() {}
     
-    public func load() -> AnyPublisher<SlipVO, Error> {
+    public func load() -> AnyPublisher<SlipVO, NetworkErrorVO> {
         return Just(SlipVO.mock)
-            .setFailureType(to: Error.self)
+            .setFailureType(to: NetworkErrorVO.self)
             .eraseToAnyPublisher()
     }
     

--- a/Projects/Domain/Sources/VO/NetworkErrorVO.swift
+++ b/Projects/Domain/Sources/VO/NetworkErrorVO.swift
@@ -1,0 +1,25 @@
+//
+//  ErrorVO.swift
+//  Domain
+//
+//  Created by Lee Myeonghwan on 2023/06/30.
+//  Copyright © 2023 Lito. All rights reserved.
+//
+
+import Foundation
+
+public enum NetworkErrorVO: Error {
+    
+    case retryableError
+    case fatalError
+    
+    public var localizedString: String {
+        switch self {
+        case .retryableError:
+            return "일시적인 네트워크 오류입니다.\n다시 시도 해주세요"
+        case .fatalError:
+            return "치명적 오류입니다. 빠른 시일 내 복구하겠습니다."
+        }
+    }
+    
+}

--- a/Projects/Presentation/Sources/Common/ErrorView.swift
+++ b/Projects/Presentation/Sources/Common/ErrorView.swift
@@ -8,32 +8,39 @@
 
 import Foundation
 import SwiftUI
+import Domain
 
 struct ErrorView: View {
-    let error: Error
+    let error: NetworkErrorVO
     let retryAction: () -> Void
     
     //TODO: 정의된 Error에 따라 보여줄 view build
+    // retryable Error: 로깅 + viewModel의 메소드 재실행
+    // fatal Error: 로깅 + 가능한 다른 처리 필요
     
     var body: some View {
         VStack {
             Text("An Error Occured")
                 .font(.title)
-            Text(error.localizedDescription)
+            Text(error.localizedString)
                 .font(.callout)
                 .multilineTextAlignment(.center)
                 .padding(.bottom, 40).padding()
-            Button(action: retryAction, label: { Text("Retry").bold() })
+            if error == .retryableError {
+                Button(action: retryAction, label: { Text("Retry").bold() })
+            }
         }
     }
 }
-
-#if DEBUG
-struct ErrorView_Previews: PreviewProvider {
-    static var previews: some View {
-        ErrorView(error: NSError(domain: "", code: 0, userInfo: [
-            NSLocalizedDescriptionKey: "Something went wrong"]),
-                  retryAction: { })
-    }
-}
-#endif
+//
+//#if DEBUG
+//struct ErrorView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ErrorView(error:
+//                    ErrorVO.presentationError(NSError(domain: "", code: 0, userInfo: [
+//                        NSLocalizedDescriptionKey: "Something went wrong"]))
+//                        ,retryAction: {}
+//        )
+//    }
+//}
+//#endif

--- a/Projects/Presentation/Sources/Common/Lodable.swift
+++ b/Projects/Presentation/Sources/Common/Lodable.swift
@@ -8,13 +8,14 @@
 
 import Foundation
 import SwiftUI
+import Domain
 
 public enum Loadable<T> {
 
     case notRequested
     case isLoading(last: T?, cancelBag: CancelBag)
     case loaded(T)
-    case failed(Error)
+    case failed(NetworkErrorVO)
 
     var value: T? {
         switch self {
@@ -44,11 +45,7 @@ extension Loadable {
             if let last = last {
                 self = .loaded(last)
             } else {
-                let error = NSError(
-                    domain: NSCocoaErrorDomain, code: NSUserCancelledError,
-                    userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("Canceled by user",
-                                                                            comment: "")])
-                self = .failed(error)
+                self = .failed(.retryableError)
             }
         default: break
         }
@@ -66,7 +63,7 @@ extension Loadable {
                 return .loaded(try transform(value))
             }
         } catch {
-            return .failed(error)
+            return .failed(.fatalError)
         }
     }
 }

--- a/Projects/Presentation/Sources/Common/Publisher+Extension.swift
+++ b/Projects/Presentation/Sources/Common/Publisher+Extension.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Combine
+import Domain
 
 extension Publisher {
     
@@ -26,17 +27,16 @@ extension Publisher {
     func sinkToLoadable(_ completion: @escaping (Loadable<Output>) -> Void) -> AnyCancellable {
         return sink(receiveCompletion: { subscriptionCompletion in
             if let error = subscriptionCompletion.error {
-                completion(.failed(error))
+                switch error {
+                case .fatalError:
+                    completion(.failed(.fatalError))
+                case .retryableError:
+                    completion(.failed(.retryableError))
+                }
             }
         }, receiveValue: { value in
             completion(.loaded(value))
         })
-    }
-    
-    func extractUnderlyingError() -> Publishers.MapError<Self, Failure> {
-        mapError {
-            ($0.underlyingError as? Failure) ?? $0
-        }
     }
     
     /// Holds the downstream delivery of output until the specified time interval passed after the subscription
@@ -56,21 +56,11 @@ extension Publisher {
     }
 }
 
-private extension Error {
-    var underlyingError: Error? {
-        let nsError = self as NSError
-        if nsError.domain == NSURLErrorDomain && nsError.code == -1009 {
-            // "The Internet connection appears to be offline."
-            return self
-        }
-        return nsError.userInfo[NSUnderlyingErrorKey] as? Error
-    }
-}
-
 extension Subscribers.Completion {
-    var error: Failure? {
+    var error: NetworkErrorVO? {
         switch self {
-        case let .failure(error): return error
+        case let .failure(error):
+            return error as? NetworkErrorVO
         default: return nil
         }
     }

--- a/Projects/Presentation/Sources/Home/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/HomeView.swift
@@ -36,8 +36,8 @@ public struct HomeView: View {
             loadingView
         case let .loaded(slip):
             loadedView(slip)
-        case let .failed(error):
-            failedView(error)
+        case let .failed(errorType):
+            failedView(errorType)
         }
     }
 }
@@ -53,7 +53,7 @@ private extension HomeView {
        ProgressView()
     }
     
-    func failedView(_ error: Error) -> some View {
+    func failedView(_ error: NetworkErrorVO) -> some View {
         ErrorView(error: error, retryAction: self.viewModel.loadSlip)
     }
     

--- a/Projects/Presentation/Sources/Home/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/HomeView.swift
@@ -36,8 +36,8 @@ public struct HomeView: View {
             loadingView
         case let .loaded(slip):
             loadedView(slip)
-        case let .failed(errorType):
-            failedView(errorType)
+        case let .failed(error):
+            failedView(error)
         }
     }
 }


### PR DESCRIPTION
## 설명
MoyaError -> NetworkErrorDTO -> NetworkErrorVO

에러의 변환을 거치며 Error DTO 와 VO의 역할 분리를 설계하였습니다.

### 각각의 역할:

**NetworkErrorDTO**: 맵핑한 moyaError 를 Lito 서버의 에러 설계에 맞게 핸들링

**NetworkErrorVO**: 유저의 액션과 연관되어 에러 핸들링
(retryableError: 다시 네트워크 요청 가능, fatalError: 반드시 개발자가 고쳐야하는 에러)
