### PR TITLE
[refactor] apple 로그인 로직 리팩토링

### DIFF
--- a/Projects/App/Sources/LitoApp.swift
+++ b/Projects/App/Sources/LitoApp.swift
@@ -4,7 +4,6 @@ import Presentation
 import Domain
 import Swinject
 import KakaoSDKCommon
-import KakaoSDKAuth
 
 @main
 struct LitoApp: App {

--- a/Projects/Data/Sources/DataSource/OAuthServiceDataSource.swift
+++ b/Projects/Data/Sources/DataSource/OAuthServiceDataSource.swift
@@ -14,8 +14,7 @@ import KakaoSDKUser
 
 public protocol OAuthServiceDataSource {
     
-    func performAppleLogin()
-    var appleLoginSubject: PassthroughSubject<Result<OAuth.AppleDTO, ErrorVO>, Never> { get }
+    func appleLogin() -> AnyPublisher<OAuth.AppleDTO, ErrorVO>
     func kakaoLogin() -> AnyPublisher<OAuth.KakaoDTO, ErrorVO>
     
 }
@@ -24,16 +23,34 @@ public class DefaultOAuthServiceDataSource: NSObject, OAuthServiceDataSource, AS
     
     public override init() {}
     
-    public func performAppleLogin() {
+    private let appleLoginSubject = PassthroughSubject<Result<OAuth.AppleDTO, ErrorVO>, Never>()
+    
+    private var appleLoginPublisher: AnyPublisher<OAuth.AppleDTO, ErrorVO> {
+        appleLoginSubject
+            .flatMap { result -> AnyPublisher<OAuth.AppleDTO, ErrorVO> in
+                switch result {
+                case .success(let appleDTO):
+                    return Just(appleDTO)
+                        .setFailureType(to: ErrorVO.self)
+                        .eraseToAnyPublisher()
+                case .failure(let error):
+                    return Fail(error: error)
+                        .eraseToAnyPublisher()
+                }
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    public func appleLogin() -> AnyPublisher<OAuth.AppleDTO, ErrorVO> {
         let provider = ASAuthorizationAppleIDProvider()
         let request = provider.createRequest()
         request.requestedScopes = [.fullName, .email]
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = self
         controller.performRequests()
+        return appleLoginPublisher
+            .eraseToAnyPublisher()
     }
-    
-    public let appleLoginSubject = PassthroughSubject<Result<OAuth.AppleDTO, ErrorVO>, Never>()
     
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         appleLoginSubject.send(.failure(.retryableError))

--- a/Projects/Data/Sources/DataSource/OAuthServiceDataSource.swift
+++ b/Projects/Data/Sources/DataSource/OAuthServiceDataSource.swift
@@ -49,7 +49,6 @@ public class DefaultOAuthServiceDataSource: NSObject, OAuthServiceDataSource, AS
         controller.delegate = self
         controller.performRequests()
         return appleLoginPublisher
-            .eraseToAnyPublisher()
     }
     
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {

--- a/Projects/Data/Sources/Repository/LoginRepository.swift
+++ b/Projects/Data/Sources/Repository/LoginRepository.swift
@@ -18,23 +18,12 @@ final public class DefaultLoginRepository: LoginRepository {
         self.dataSource = dataSource
     }
     
-    public func performAppleLogin() {
-        dataSource.performAppleLogin()
-    }
-    
-    public func bindAppleLogin() -> AnyPublisher<Result<OAuth.AppleVO, ErrorVO>, Never> {
-        dataSource.appleLoginSubject
-            .map { result in
-                switch result {
-                case .success(let appleDTO):
-                    return .success(appleDTO.toVO())
-                case .failure(let errorVO):
-                    return .failure(errorVO)
-                }
-            }
+    public func appleLogin() -> AnyPublisher<OAuth.AppleVO, ErrorVO> {
+        dataSource.appleLogin()
+            .map { $0.toVO() }
             .eraseToAnyPublisher()
     }
-
+    
     public func kakaoLogin() -> AnyPublisher<OAuth.KakaoVO, ErrorVO> {
         dataSource.kakaoLogin()
             .map { $0.toVO() }

--- a/Projects/Domain/Sources/RepositoryProtocol/LoginRepository.swift
+++ b/Projects/Domain/Sources/RepositoryProtocol/LoginRepository.swift
@@ -11,8 +11,7 @@ import Combine
 
 public protocol LoginRepository {
     
-    func performAppleLogin()
-    func bindAppleLogin() -> AnyPublisher<Result<OAuth.AppleVO, ErrorVO>, Never>
+    func appleLogin() -> AnyPublisher<OAuth.AppleVO, ErrorVO>
     func kakaoLogin() -> AnyPublisher<OAuth.KakaoVO, ErrorVO>
     
 }

--- a/Projects/Domain/Sources/Services/LoginUseCase.swift
+++ b/Projects/Domain/Sources/Services/LoginUseCase.swift
@@ -12,8 +12,7 @@ import Foundation
 public protocol LoginUseCase {
     
     func kakaoLogin() -> AnyPublisher<RequestResultVO, ErrorVO>
-    func performAppleLogin()
-    func bindAppleLogin() -> AnyPublisher<Result<RequestResultVO, ErrorVO>, Never>
+    func appleLogin() -> AnyPublisher<RequestResultVO, ErrorVO>
     
 }
 
@@ -28,20 +27,9 @@ public final class DefaultLoginUseCase: LoginUseCase {
         self.repository = repository
     }
     
-    public func performAppleLogin() {
-        repository.performAppleLogin()
-    }
-    
-    public func bindAppleLogin() -> AnyPublisher<Result<RequestResultVO, ErrorVO>, Never> {
-        repository.bindAppleLogin()
-            .map { result in
-                switch result {
-                case .success(_):
-                    return .success(.succeed)
-                case .failure(let error):
-                    return .failure(error)
-                }
-            }
+    public func appleLogin() -> AnyPublisher<RequestResultVO, ErrorVO> {
+        repository.appleLogin()
+            .map { _ in .succeed }
             .eraseToAnyPublisher()
     }
     

--- a/Projects/Presentation/Sources/Views/Login/LoginView.swift
+++ b/Projects/Presentation/Sources/Views/Login/LoginView.swift
@@ -30,7 +30,7 @@ public struct LoginView: View {
             VStack {
                 SignInWithAppleButtonView()
                     .onTapGesture {
-                        viewModel.performAppleLogin()
+                        viewModel.appleLogin()
                     }
                     .frame(width: 280, height: 45)
                     .cornerRadius(10)

--- a/Projects/Presentation/Sources/Views/Login/LoginViewModel.swift
+++ b/Projects/Presentation/Sources/Views/Login/LoginViewModel.swift
@@ -22,7 +22,6 @@ final public class LoginViewModel: BaseViewModel, ObservableObject {
         self.useCase = useCase
         self.loginFeedback = loginFeedback
         super.init(coordinator: coordinator)
-        bindAppleLogin()
     }
     
     public func kakaoLogin() {
@@ -30,48 +29,36 @@ final public class LoginViewModel: BaseViewModel, ObservableObject {
             .sinkToResult({ result in
                 switch result {
                 case .success(_):
-                    print("kakao login Sucess")
                     self.coordinator.push(.profileSettingView("test"))
                 case .failure(let error):
                     switch error {
                     case .fatalError:
                         self.errorObject.error = error
-                        self.errorObject.retryAction = self.performAppleLogin
                     case .retryableError:
-                        // self.loginFeedback = .idle
                         self.errorObject.error = error
-                        self.errorObject.retryAction = self.performAppleLogin
+                        self.errorObject.retryAction = self.kakaoLogin
                     }
                 }
             })
             .store(in: cancelBag)
     }
     
-    public func performAppleLogin() {
-        useCase.performAppleLogin()
-    }
-    
-    private func bindAppleLogin() {
-        useCase.bindAppleLogin()
-            .sink(receiveValue: { result in
+    public func appleLogin() {
+        useCase.appleLogin()
+            .sinkToResult({ result in
                 switch result {
                 case .success(_):
-                    print("apple login Sucess")
                     self.coordinator.push(.profileSettingView("test"))
-                    //TODO: routing to next view
                 case .failure(let error):
                     switch error {
                     case .fatalError:
                         self.errorObject.error = error
-                        self.errorObject.retryAction = self.performAppleLogin
                     case .retryableError:
                         self.errorObject.error = error
-                        self.errorObject.retryAction = self.performAppleLogin
-//                        self.loginFeedback = .idle
+                        self.errorObject.retryAction = self.appleLogin
                     }
                 }
             })
             .store(in: cancelBag)
     }
-    
 }


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->

 기존 복잡하던 로직 (performAppleLogin, bindAppleLogin 함수 두개를 사용하여 처리)을 appleLogin 함수 하나로 처리되도록 변경. 

이로써 kakaoLogin과 같이 일관성있는 처리가 가능해짐.

appleLoginSubject(PassthroughSubject) 가 보내준 결과(애플 로그인 성공 or 에러)를 다시 publish 하는 appleLoginPublisher 만들어서 리팩토링 하였음.
