### PR TITLE
[refactor] error 핸들링 리팩토링 (리뷰용)

### DIFF
--- a/Projects/App/Sources/LitoApp.swift
+++ b/Projects/App/Sources/LitoApp.swift
@@ -4,7 +4,6 @@ import Presentation
 import Domain
 import Swinject
 import KakaoSDKCommon
-import KakaoSDKAuth
 
 @main
 struct LitoApp: App {

--- a/Projects/Data/Sources/DTO+Mapping/ErrorDTO/OAuthErrorDTO.swift
+++ b/Projects/Data/Sources/DTO+Mapping/ErrorDTO/OAuthErrorDTO.swift
@@ -7,3 +7,32 @@
 //
 
 import Foundation
+import Domain
+
+public enum OAuthErrorDTO: Error {
+    
+        case apple(Error)
+        case kakao(Error)
+    
+        public var debugString: String {
+            switch self {
+            case .apple(let error):
+                return "⛑️ Apple Login Error: \(error.localizedDescription) "
+            case .kakao(let error):
+                return "⛑️ Kakao Login Error: \(error.localizedDescription)"
+            }
+        }
+    
+    public func toVO() -> OAuthErrorVO {
+        switch self {
+        case .apple(let error):
+            // apple 에서 정의된 errorCode를 대조하여 error.localizedDescription에서 파싱하여 상황에 맞게 VO를 return?
+            let errorCode = error.localizedDescription
+            return OAuthErrorVO.internalServerError
+        case .kakao(let error):
+            // kakao 에서 정의된 errorCode를 대조하여 error.localizedDescription에서 파싱하여 상황에 맞게 VO를 return?
+            let errorCode = error.localizedDescription
+            return OAuthErrorVO.internalServerError
+        }
+    }
+}

--- a/Projects/Data/Sources/DataSource/OAuthServiceDataSource.swift
+++ b/Projects/Data/Sources/DataSource/OAuthServiceDataSource.swift
@@ -14,8 +14,7 @@ import KakaoSDKUser
 
 public protocol OAuthServiceDataSource {
     
-    func performAppleLogin()
-    var appleLoginSubject: PassthroughSubject<Result<OAuth.AppleDTO, ErrorVO>, Never> { get }
+    func appleLogin() -> AnyPublisher<OAuth.AppleDTO, ErrorVO>
     func kakaoLogin() -> AnyPublisher<OAuth.KakaoDTO, ErrorVO>
     
 }
@@ -24,16 +23,34 @@ public class DefaultOAuthServiceDataSource: NSObject, OAuthServiceDataSource, AS
     
     public override init() {}
     
-    public func performAppleLogin() {
+    private let appleLoginSubject = PassthroughSubject<Result<OAuth.AppleDTO, ErrorVO>, Never>()
+    
+    private var appleLoginPublisher: AnyPublisher<OAuth.AppleDTO, ErrorVO> {
+        appleLoginSubject
+            .flatMap { result -> AnyPublisher<OAuth.AppleDTO, ErrorVO> in
+                switch result {
+                case .success(let appleDTO):
+                    return Just(appleDTO)
+                        .setFailureType(to: ErrorVO.self)
+                        .eraseToAnyPublisher()
+                case .failure(let error):
+                    return Fail(error: error)
+                        .eraseToAnyPublisher()
+                }
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    public func appleLogin() -> AnyPublisher<OAuth.AppleDTO, ErrorVO> {
         let provider = ASAuthorizationAppleIDProvider()
         let request = provider.createRequest()
         request.requestedScopes = [.fullName, .email]
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = self
         controller.performRequests()
+        return appleLoginPublisher
+            .eraseToAnyPublisher()
     }
-    
-    public let appleLoginSubject = PassthroughSubject<Result<OAuth.AppleDTO, ErrorVO>, Never>()
     
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         appleLoginSubject.send(.failure(.retryableError))

--- a/Projects/Data/Sources/DataSource/OAuthServiceDataSource.swift
+++ b/Projects/Data/Sources/DataSource/OAuthServiceDataSource.swift
@@ -49,7 +49,6 @@ public class DefaultOAuthServiceDataSource: NSObject, OAuthServiceDataSource, AS
         controller.delegate = self
         controller.performRequests()
         return appleLoginPublisher
-            .eraseToAnyPublisher()
     }
     
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {

--- a/Projects/Data/Sources/DataSource/OAuthServiceDataSource.swift
+++ b/Projects/Data/Sources/DataSource/OAuthServiceDataSource.swift
@@ -14,8 +14,8 @@ import KakaoSDKUser
 
 public protocol OAuthServiceDataSource {
     
-    func appleLogin() -> AnyPublisher<OAuth.AppleDTO, ErrorVO>
-    func kakaoLogin() -> AnyPublisher<OAuth.KakaoDTO, ErrorVO>
+    func appleLogin() -> AnyPublisher<OAuth.AppleDTO, Error>
+    func kakaoLogin() -> AnyPublisher<OAuth.KakaoDTO, Error>
     
 }
 
@@ -23,15 +23,15 @@ public class DefaultOAuthServiceDataSource: NSObject, OAuthServiceDataSource, AS
     
     public override init() {}
     
-    private let appleLoginSubject = PassthroughSubject<Result<OAuth.AppleDTO, ErrorVO>, Never>()
+    private let appleLoginSubject = PassthroughSubject<Result<OAuth.AppleDTO, OAuthErrorDTO>, Never>()
     
-    private var appleLoginPublisher: AnyPublisher<OAuth.AppleDTO, ErrorVO> {
+    private var appleLoginPublisher: AnyPublisher<OAuth.AppleDTO, Error> {
         appleLoginSubject
-            .flatMap { result -> AnyPublisher<OAuth.AppleDTO, ErrorVO> in
+            .flatMap { result -> AnyPublisher<OAuth.AppleDTO, Error> in
                 switch result {
                 case .success(let appleDTO):
                     return Just(appleDTO)
-                        .setFailureType(to: ErrorVO.self)
+                        .setFailureType(to: Error.self)
                         .eraseToAnyPublisher()
                 case .failure(let error):
                     return Fail(error: error)
@@ -41,7 +41,7 @@ public class DefaultOAuthServiceDataSource: NSObject, OAuthServiceDataSource, AS
             .eraseToAnyPublisher()
     }
     
-    public func appleLogin() -> AnyPublisher<OAuth.AppleDTO, ErrorVO> {
+    public func appleLogin() -> AnyPublisher<OAuth.AppleDTO, Error> {
         let provider = ASAuthorizationAppleIDProvider()
         let request = provider.createRequest()
         request.requestedScopes = [.fullName, .email]
@@ -52,7 +52,7 @@ public class DefaultOAuthServiceDataSource: NSObject, OAuthServiceDataSource, AS
     }
     
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        appleLoginSubject.send(.failure(.retryableError))
+        appleLoginSubject.send(.failure(.apple(error)))
     }
     
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
@@ -68,7 +68,7 @@ public class DefaultOAuthServiceDataSource: NSObject, OAuthServiceDataSource, AS
         }
     }
     
-    public func kakaoLogin() -> AnyPublisher<OAuth.KakaoDTO, ErrorVO> {
+    public func kakaoLogin() -> AnyPublisher<OAuth.KakaoDTO, Error> {
         if UserApi.isKakaoTalkLoginAvailable() {
             return kakaoLoginWithApp()
         } else {
@@ -76,15 +76,15 @@ public class DefaultOAuthServiceDataSource: NSObject, OAuthServiceDataSource, AS
         }
     }
     
-    private func kakaoLoginWithApp() -> AnyPublisher<OAuth.KakaoDTO, ErrorVO> {
-        return Future<OAuth.KakaoDTO, ErrorVO> { promise in
+    private func kakaoLoginWithApp() -> AnyPublisher<OAuth.KakaoDTO, Error> {
+        return Future<OAuth.KakaoDTO, Error> { promise in
             UserApi.shared.loginWithKakaoTalk { (_, error) in
-                if error != nil {
-                    return promise(.failure(ErrorVO.retryableError))
+                if let error = error {
+                    return promise(.failure(OAuthErrorDTO.kakao(error)))
                 }
                 UserApi.shared.me { (user, error) in
-                    if error != nil {
-                        return promise(.failure(ErrorVO.retryableError))
+                    if let error = error {
+                        return promise(.failure(OAuthErrorDTO.apple(error)))
                     }
                     
                     if let userInfo = user?.kakaoAccount, let userId = user?.id {
@@ -99,15 +99,15 @@ public class DefaultOAuthServiceDataSource: NSObject, OAuthServiceDataSource, AS
         }.eraseToAnyPublisher()
     }
     
-    private func kakaoLoginWithAccount() -> AnyPublisher<OAuth.KakaoDTO, ErrorVO> {
-        return Future<OAuth.KakaoDTO, ErrorVO> { promise in
+    private func kakaoLoginWithAccount() -> AnyPublisher<OAuth.KakaoDTO, Error> {
+        return Future<OAuth.KakaoDTO, Error> { promise in
             UserApi.shared.loginWithKakaoAccount { (_, error) in
-                if error != nil {
-                    return promise(.failure(ErrorVO.retryableError))
+                if let error = error {
+                    return promise(.failure(OAuthErrorDTO.kakao(error)))
                 }
                 UserApi.shared.me { (user, error) in
-                    if error != nil {
-                        return promise(.failure(ErrorVO.retryableError))
+                    if let error = error {
+                        return promise(.failure(OAuthErrorDTO.kakao(error)))
                     }
                     
                     if let userInfo = user?.kakaoAccount, let userId = user?.id {

--- a/Projects/Data/Sources/Repository/LoginRepository.swift
+++ b/Projects/Data/Sources/Repository/LoginRepository.swift
@@ -18,23 +18,12 @@ final public class DefaultLoginRepository: LoginRepository {
         self.dataSource = dataSource
     }
     
-    public func performAppleLogin() {
-        dataSource.performAppleLogin()
-    }
-    
-    public func bindAppleLogin() -> AnyPublisher<Result<OAuth.AppleVO, ErrorVO>, Never> {
-        dataSource.appleLoginSubject
-            .map { result in
-                switch result {
-                case .success(let appleDTO):
-                    return .success(appleDTO.toVO())
-                case .failure(let errorVO):
-                    return .failure(errorVO)
-                }
-            }
+    public func appleLogin() -> AnyPublisher<OAuth.AppleVO, ErrorVO> {
+        dataSource.appleLogin()
+            .map { $0.toVO() }
             .eraseToAnyPublisher()
     }
-
+    
     public func kakaoLogin() -> AnyPublisher<OAuth.KakaoVO, ErrorVO> {
         dataSource.kakaoLogin()
             .map { $0.toVO() }

--- a/Projects/Data/Sources/Repository/LoginRepository.swift
+++ b/Projects/Data/Sources/Repository/LoginRepository.swift
@@ -18,14 +18,34 @@ final public class DefaultLoginRepository: LoginRepository {
         self.dataSource = dataSource
     }
     
-    public func appleLogin() -> AnyPublisher<OAuth.AppleVO, ErrorVO> {
+    public func appleLogin() -> AnyPublisher<OAuth.AppleVO, Error> {
         dataSource.appleLogin()
+            // 1차적으로 이곳에서 OAuth error를 핸들링
+            // 만약 catch한 error 가 추가적인 액션을 통해 해결 가능성 있는 error 라면 repository or useCase 어디서 처리 해야할까?
+            .catch({ error -> Fail in
+                if let oauthError = error as? OAuthErrorDTO {
+                    #if DEBUG
+                    print(oauthError.debugString)
+                    #endif
+                    return Fail(error: oauthError.toVO())
+                }
+                return Fail(error: ErrorVO.fatalError)
+            })
             .map { $0.toVO() }
             .eraseToAnyPublisher()
     }
     
-    public func kakaoLogin() -> AnyPublisher<OAuth.KakaoVO, ErrorVO> {
+    public func kakaoLogin() -> AnyPublisher<OAuth.KakaoVO, Error> {
         dataSource.kakaoLogin()
+            .catch({ error -> Fail in
+                if let oauthError = error as? OAuthErrorDTO {
+                    #if DEBUG
+                    print(oauthError.debugString)
+                    #endif
+                    return Fail(error: oauthError.toVO())
+                }
+                return Fail(error: ErrorVO.fatalError)
+            })
             .map { $0.toVO() }
             .eraseToAnyPublisher()
     }

--- a/Projects/Domain/Sources/RepositoryProtocol/LoginRepository.swift
+++ b/Projects/Domain/Sources/RepositoryProtocol/LoginRepository.swift
@@ -11,8 +11,7 @@ import Combine
 
 public protocol LoginRepository {
     
-    func performAppleLogin()
-    func bindAppleLogin() -> AnyPublisher<Result<OAuth.AppleVO, ErrorVO>, Never>
+    func appleLogin() -> AnyPublisher<OAuth.AppleVO, ErrorVO>
     func kakaoLogin() -> AnyPublisher<OAuth.KakaoVO, ErrorVO>
     
 }

--- a/Projects/Domain/Sources/RepositoryProtocol/LoginRepository.swift
+++ b/Projects/Domain/Sources/RepositoryProtocol/LoginRepository.swift
@@ -11,7 +11,7 @@ import Combine
 
 public protocol LoginRepository {
     
-    func appleLogin() -> AnyPublisher<OAuth.AppleVO, ErrorVO>
-    func kakaoLogin() -> AnyPublisher<OAuth.KakaoVO, ErrorVO>
+    func appleLogin() -> AnyPublisher<OAuth.AppleVO, Error>
+    func kakaoLogin() -> AnyPublisher<OAuth.KakaoVO, Error>
     
 }

--- a/Projects/Domain/Sources/Services/LoginUseCase.swift
+++ b/Projects/Domain/Sources/Services/LoginUseCase.swift
@@ -12,8 +12,7 @@ import Foundation
 public protocol LoginUseCase {
     
     func kakaoLogin() -> AnyPublisher<RequestResultVO, ErrorVO>
-    func performAppleLogin()
-    func bindAppleLogin() -> AnyPublisher<Result<RequestResultVO, ErrorVO>, Never>
+    func appleLogin() -> AnyPublisher<RequestResultVO, ErrorVO>
     
 }
 
@@ -28,20 +27,9 @@ public final class DefaultLoginUseCase: LoginUseCase {
         self.repository = repository
     }
     
-    public func performAppleLogin() {
-        repository.performAppleLogin()
-    }
-    
-    public func bindAppleLogin() -> AnyPublisher<Result<RequestResultVO, ErrorVO>, Never> {
-        repository.bindAppleLogin()
-            .map { result in
-                switch result {
-                case .success(_):
-                    return .success(.succeed)
-                case .failure(let error):
-                    return .failure(error)
-                }
-            }
+    public func appleLogin() -> AnyPublisher<RequestResultVO, ErrorVO> {
+        repository.appleLogin()
+            .map { _ in .succeed }
             .eraseToAnyPublisher()
     }
     

--- a/Projects/Domain/Sources/VO/OAuthErrorVO.swift
+++ b/Projects/Domain/Sources/VO/OAuthErrorVO.swift
@@ -1,0 +1,27 @@
+//
+//  OAuthErrorVO.swift
+//  Domain
+//
+//  Created by Lee Myeonghwan on 2023/07/07.
+//  Copyright © 2023 com.lito. All rights reserved.
+//
+
+import Foundation
+
+public enum OAuthErrorVO: Error {
+    
+    case oauthServerError
+    case internalServerError
+    case cancelByUser
+    
+    public var debugString: String {
+        switch self {
+        case .oauthServerError:
+            return "⛑️ oauthServerError"
+        case .internalServerError:
+            return "⛑️ internalServerError"
+        case .cancelByUser:
+            return "⛑️ cancelByUser"
+        }
+    }
+}

--- a/Projects/Presentation/Sources/Views/Login/LoginView.swift
+++ b/Projects/Presentation/Sources/Views/Login/LoginView.swift
@@ -30,7 +30,7 @@ public struct LoginView: View {
             VStack {
                 SignInWithAppleButtonView()
                     .onTapGesture {
-                        viewModel.performAppleLogin()
+                        viewModel.appleLogin()
                     }
                     .frame(width: 280, height: 45)
                     .cornerRadius(10)

--- a/Projects/Presentation/Sources/Views/Login/LoginViewModel.swift
+++ b/Projects/Presentation/Sources/Views/Login/LoginViewModel.swift
@@ -31,12 +31,14 @@ final public class LoginViewModel: BaseViewModel, ObservableObject {
                 case .success(_):
                     self.coordinator.push(.profileSettingView("test"))
                 case .failure(let error):
-                    switch error {
-                    case .fatalError:
-                        self.errorObject.error = error
-                    case .retryableError:
-                        self.errorObject.error = error
-                        self.errorObject.retryAction = self.kakaoLogin
+                    if let errorVO = error as? ErrorVO {
+                        switch errorVO {
+                        case .fatalError:
+                            self.errorObject.error = errorVO
+                        case .retryableError:
+                            self.errorObject.error = errorVO
+                            self.errorObject.retryAction = self.appleLogin
+                        }
                     }
                 }
             })
@@ -50,12 +52,14 @@ final public class LoginViewModel: BaseViewModel, ObservableObject {
                 case .success(_):
                     self.coordinator.push(.profileSettingView("test"))
                 case .failure(let error):
-                    switch error {
-                    case .fatalError:
-                        self.errorObject.error = error
-                    case .retryableError:
-                        self.errorObject.error = error
-                        self.errorObject.retryAction = self.appleLogin
+                    if let errorVO = error as? ErrorVO {
+                        switch errorVO {
+                        case .fatalError:
+                            self.errorObject.error = errorVO
+                        case .retryableError:
+                            self.errorObject.error = errorVO
+                            self.errorObject.retryAction = self.appleLogin
+                        }
                     }
                 }
             })

--- a/Projects/Presentation/Sources/Views/Login/LoginViewModel.swift
+++ b/Projects/Presentation/Sources/Views/Login/LoginViewModel.swift
@@ -22,7 +22,6 @@ final public class LoginViewModel: BaseViewModel, ObservableObject {
         self.useCase = useCase
         self.loginFeedback = loginFeedback
         super.init(coordinator: coordinator)
-        bindAppleLogin()
     }
     
     public func kakaoLogin() {
@@ -30,48 +29,36 @@ final public class LoginViewModel: BaseViewModel, ObservableObject {
             .sinkToResult({ result in
                 switch result {
                 case .success(_):
-                    print("kakao login Sucess")
                     self.coordinator.push(.profileSettingView("test"))
                 case .failure(let error):
                     switch error {
                     case .fatalError:
                         self.errorObject.error = error
-                        self.errorObject.retryAction = self.performAppleLogin
                     case .retryableError:
-                        // self.loginFeedback = .idle
                         self.errorObject.error = error
-                        self.errorObject.retryAction = self.performAppleLogin
+                        self.errorObject.retryAction = self.kakaoLogin
                     }
                 }
             })
             .store(in: cancelBag)
     }
     
-    public func performAppleLogin() {
-        useCase.performAppleLogin()
-    }
-    
-    private func bindAppleLogin() {
-        useCase.bindAppleLogin()
-            .sink(receiveValue: { result in
+    public func appleLogin() {
+        useCase.appleLogin()
+            .sinkToResult({ result in
                 switch result {
                 case .success(_):
-                    print("apple login Sucess")
                     self.coordinator.push(.profileSettingView("test"))
-                    //TODO: routing to next view
                 case .failure(let error):
                     switch error {
                     case .fatalError:
                         self.errorObject.error = error
-                        self.errorObject.retryAction = self.performAppleLogin
                     case .retryableError:
                         self.errorObject.error = error
-                        self.errorObject.retryAction = self.performAppleLogin
-//                        self.loginFeedback = .idle
+                        self.errorObject.retryAction = self.appleLogin
                     }
                 }
             })
             .store(in: cancelBag)
     }
-    
 }


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- Swift Error 타입을 그대로 사용하여, catch 로 특정 에러에 대해 핸들링 하는 방식으로 리팩토링.

(Publisher 의 스트림에서 Failure 케이스를 각각의 Error 타입으로 명시해야하는 문제를 수정하였습니다.)

Q1. OAuthErrorDTO -> OAuthErrorVO 로 변환되는 상황을 가정해보고 코드를 작성해보았는데 맞게 했는지 모르겠습니다. (아직 ErrorDTO가 ErrorVO 로 변환되어야하는 상황과 Error DTO, VO 각각의 역할을 명확하게 모르겠습니다.)

Q2. Repository or UseCase 에서 각각 어떤 Error 를 처리해야하고, 해결 가능성 있는 에러에 대한 추가적인 액션은 어디서 해야할까요?
