### PR TITLE
[fix] apple 로그인 심사거절 수정

### DIFF
--- a/Projects/Data/Sources/DTO+Mapping/OAuthDTO.swift
+++ b/Projects/Data/Sources/DTO+Mapping/OAuthDTO.swift
@@ -14,9 +14,10 @@ extension OAuth {
     public struct AppleDTO {
         let userIdentifier: String
         let userEmail: String?
+        let userName: String?
         
         func toVO() -> AppleVO {
-            return AppleVO(userIdentifier: userIdentifier, userEmail: userEmail ?? "")
+            return AppleVO(userIdentifier: userIdentifier, userEmail: userEmail ?? "", userName: userName)
         }
     }
     

--- a/Projects/Data/Sources/DataSource/OAuthDataSource.swift
+++ b/Projects/Data/Sources/DataSource/OAuthDataSource.swift
@@ -45,7 +45,7 @@ final public class DefaultOAuthDataSource: NSObject, OAuthDataSource, ASAuthoriz
     public func appleLogin() -> AnyPublisher<OAuth.AppleDTO, Error> {
         let provider = ASAuthorizationAppleIDProvider()
         let request = provider.createRequest()
-        request.requestedScopes = [.email]
+        request.requestedScopes = [.email, .fullName]
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = self
         controller.performRequests()
@@ -69,7 +69,8 @@ final public class DefaultOAuthDataSource: NSObject, OAuthDataSource, ASAuthoriz
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
             let userIdentifier = appleIDCredential.user
             let userEmail = appleIDCredential.email
-            let appleDTO = OAuth.AppleDTO(userIdentifier: userIdentifier, userEmail: userEmail)
+            let userName = appleIDCredential.fullName?.formatted(.name(style: .long))
+            let appleDTO = OAuth.AppleDTO(userIdentifier: userIdentifier, userEmail: userEmail, userName: userName)
             appleLoginSubject.send(.success(appleDTO))
         default:
             break

--- a/Projects/Data/Sources/Network/Auth/AuthPlugin.swift
+++ b/Projects/Data/Sources/Network/Auth/AuthPlugin.swift
@@ -21,7 +21,7 @@ struct AuthPlugin: PluginType {
         UserAPI.patchUserInfo(ProfileInfoDTO(accessToken: "")).pathWithMethod,
         UserAPI.setNotiAcceptance(AlarmAcceptanceDTO(getAlarm: false, accessToken: "")).pathWithMethod,
         FileAPI.setProfileImage(ProfileImageDTO(image: Data(), accessToken: "")).pathWithMethod,
-        AuthAPI.appleLogin(appleVO: OAuth.AppleVO(userIdentifier: "", userEmail: "")).pathWithMethod,
+        AuthAPI.appleLogin(appleVO: OAuth.AppleVO(userIdentifier: "", userEmail: "", userName: nil)).pathWithMethod,
         AuthAPI.kakaoLogin(kakaoVO: OAuth.KakaoVO(userIdentifier: "", userEmail: "")).pathWithMethod
     ]
     

--- a/Projects/Domain/Sources/UseCase/LoginUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/LoginUseCase.swift
@@ -40,7 +40,7 @@ public final class DefaultLoginUseCase: LoginUseCase {
                             let userAuthVO = UserAuthVO(accessToken: loginVO.accessToken, refreashToken: loginVO.refreshToken, refreshTokenExpirationTime: loginVO.refreshTokenExpirationTime, userId: loginVO.userId)
                             KeyChainManager.createUserInfo(userAuthVO: userAuthVO)
                         }
-                        return loginVO.registered ? .registered : .unregistered(userAuthVO: UserAuthVO(accessToken: loginVO.accessToken, refreashToken: loginVO.refreshToken, refreshTokenExpirationTime: loginVO.refreshTokenExpirationTime, userId: loginVO.userId))
+                        return loginVO.registered ? .registered : .unregistered(userAuthVO: UserAuthVO(accessToken: loginVO.accessToken, refreashToken: loginVO.refreshToken, refreshTokenExpirationTime: loginVO.refreshTokenExpirationTime, userId: loginVO.userId, userName: appleVO.userName ?? ""))
                     }
                     .eraseToAnyPublisher()
             }

--- a/Projects/Domain/Sources/VO/OAuthVO.swift
+++ b/Projects/Domain/Sources/VO/OAuthVO.swift
@@ -16,10 +16,12 @@ public enum OAuth {
     public struct AppleVO {
         public let userIdentifier: String
         public let userEmail: String?
+        public let userName: String?
         
-        public init(userIdentifier: String, userEmail: String?) {
+        public init(userIdentifier: String, userEmail: String?, userName: String?) {
             self.userIdentifier = userIdentifier
             self.userEmail = userEmail
+            self.userName = userName
         }
     }
     

--- a/Projects/Domain/Sources/VO/UserAuthVO.swift
+++ b/Projects/Domain/Sources/VO/UserAuthVO.swift
@@ -13,12 +13,13 @@ public struct UserAuthVO: Hashable {
     public let refreshToken: String
     public let refreshTokenExpirationTime: String
     public let userId: Int
+    public let userName: String
     
-    public init(accessToken: String, refreashToken: String, refreshTokenExpirationTime: String, userId: Int) {
+    public init(accessToken: String, refreashToken: String, refreshTokenExpirationTime: String, userId: Int, userName: String = "") {
         self.accessToken = accessToken
         self.refreshToken = refreashToken
         self.refreshTokenExpirationTime = refreshTokenExpirationTime
         self.userId = userId
+        self.userName = userName
     }
-    
 }

--- a/Projects/Presentation/Sources/Views/ProfileSetting/ProfileSettingView.swift
+++ b/Projects/Presentation/Sources/Views/ProfileSetting/ProfileSettingView.swift
@@ -79,6 +79,9 @@ public struct ProfileSettingView: View {
                 }
             }
         }
+        .onAppear {
+            viewModel.setName()
+        }
     }
     
     // API 에러 발생시 알려줌

--- a/Projects/Presentation/Sources/Views/ProfileSetting/ProfileSettingView.swift
+++ b/Projects/Presentation/Sources/Views/ProfileSetting/ProfileSettingView.swift
@@ -80,7 +80,7 @@ public struct ProfileSettingView: View {
             }
         }
         .onAppear {
-            viewModel.setName()
+            viewModel.viewOnAppear()
         }
     }
     

--- a/Projects/Presentation/Sources/Views/ProfileSetting/ProfileSettingViewModel.swift
+++ b/Projects/Presentation/Sources/Views/ProfileSetting/ProfileSettingViewModel.swift
@@ -112,7 +112,7 @@ public class ProfileSettingViewModel: BaseViewModel {
         })
     }
     
-    public func setName() {
+    public func viewOnAppear() {
         self.username.text = userAuthVO.userName
     }
 }

--- a/Projects/Presentation/Sources/Views/ProfileSetting/ProfileSettingViewModel.swift
+++ b/Projects/Presentation/Sources/Views/ProfileSetting/ProfileSettingViewModel.swift
@@ -111,4 +111,8 @@ public class ProfileSettingViewModel: BaseViewModel {
             }
         })
     }
+    
+    public func setName() {
+        self.username.text = userAuthVO.userName
+    }
 }


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] apple 로그인의 심사거절 이유: 이름 또 입력하게하지 마라
-> 처음 회원가입 할때 입력 안하고 자동으로 입력되도록 변경
