### PR TITLE
Fix/keyword box exceed screen/lito 267

### DIFF
--- a/Projects/Presentation/Sources/Common/Extension/String+Extension.swift
+++ b/Projects/Presentation/Sources/Common/Extension/String+Extension.swift
@@ -10,4 +10,10 @@ extension String {
     subscript(index: Int) -> String {
         return String(self[self.index(self.startIndex, offsetBy: index)])
     }
+    
+    subscript(_ range: Range<Int>) -> String {
+        let fromIndex = self.index(self.startIndex, offsetBy: range.startIndex)
+        let toIndex = self.index(self.startIndex, offsetBy: range.endIndex)
+        return String(self[fromIndex..<toIndex])
+    }
 }

--- a/Projects/Presentation/Sources/Views/ProblemDetail/ProblemDetailView.swift
+++ b/Projects/Presentation/Sources/Views/ProblemDetail/ProblemDetailView.swift
@@ -319,10 +319,10 @@ public struct ProblemDetailView: View {
     
     // 키워드 컴포넌트
     @ViewBuilder
-    private var keywordBox: some View {
+    private func keywordBox(startIdx: Int, endIdx: Int) -> some View {
         if let keyword = viewModel.problemDetailVO?.problemKeyword {
             HStack(spacing: 3) {
-                ForEach(0..<keyword.count, id: \.self) { idx in
+                ForEach(startIdx..<endIdx, id: \.self) { idx in
                     ZStack {
                         RoundedRectangle(cornerRadius: 3)
                             .strokeBorder(viewModel.IsWrongBefore ? .Border_Serve_Red  : .Border_Serve, lineWidth: 1)
@@ -357,12 +357,12 @@ public struct ProblemDetailView: View {
     // 일반 단어와 키워드 뷰컴포넌트를 구분해서 리스트에 담아주기
     private func makeAnswerBoxComponents() -> [AnyView] {
         var components = [AnyView]()
-        if let answerSplited = viewModel.answerSplited {
-            for word in answerSplited {
-                if word == viewModel.problemDetailVO?.problemKeyword {
+        if !viewModel.answerSplited.isEmpty {
+            for (idx, word) in viewModel.answerSplited.enumerated() {
+                if viewModel.keywordRange[idx].0 != -1 {
                     components.append(
                         AnyView(
-                            keywordBox
+                            keywordBox(startIdx: viewModel.keywordRange[idx].0, endIdx: viewModel.keywordRange[idx].1)
                         )
                     )
                 } else {

--- a/Projects/Presentation/Sources/Views/ProblemDetail/ProblemDetailViewModel.swift
+++ b/Projects/Presentation/Sources/Views/ProblemDetail/ProblemDetailViewModel.swift
@@ -10,6 +10,7 @@ import Domain
 import SwiftUI
 
 public class ProblemDetailViewModel: BaseViewModel {
+    private(set) var keywordRange = [(Int, Int)]()
     private let useCase: ProblemDetailUseCase
     private let keywordBoxMaxLength = 9
     let problemId: Int
@@ -26,7 +27,6 @@ public class ProblemDetailViewModel: BaseViewModel {
     @Published private(set) var faqIsOpened: [Bool]?
     @Published private(set) var inputErrorMessage: String = ""
     @Published private(set) var answerSplited = [String]()
-    @Published private(set) var keywordRange = [(Int, Int)]()
     @Published private(set) var isLoading: Bool = false
     @Published private(set) var isFirstTry: Bool = true
     @Published private(set) var isWrongInput: Bool = false

--- a/Projects/Presentation/Sources/Views/ProblemDetail/ProblemDetailViewModel.swift
+++ b/Projects/Presentation/Sources/Views/ProblemDetail/ProblemDetailViewModel.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 public class ProblemDetailViewModel: BaseViewModel {
     private let useCase: ProblemDetailUseCase
+    private let keywordBoxMaxLength = 9
     let problemId: Int
     let stateChangingTime = 2.0
     var showSubmittedInput: Bool {
@@ -21,10 +22,11 @@ public class ProblemDetailViewModel: BaseViewModel {
     }
     @Published var input: String = ""
     @Published private(set) var problemDetailVO: ProblemDetailVO?
-    @Published private(set) var answerSplited: [String]?
     @Published private(set) var solvingState: SolvingState = .initial
     @Published private(set) var faqIsOpened: [Bool]?
     @Published private(set) var inputErrorMessage: String = ""
+    @Published private(set) var answerSplited = [String]()
+    @Published private(set) var keywordRange = [(Int, Int)]()
     @Published private(set) var isLoading: Bool = false
     @Published private(set) var isFirstTry: Bool = true
     @Published private(set) var isWrongInput: Bool = false
@@ -157,8 +159,33 @@ public class ProblemDetailViewModel: BaseViewModel {
     // 문제에 대한 답변에서 단어별 (키워드 포함) 로 쪼개기
     private func splitSentence() {
         guard let problemDetailVO = problemDetailVO else { return }
+        let keyword = problemDetailVO.problemKeyword
         
-        let keywordDistinguished = problemDetailVO.problemAnswer.replacingOccurrences(of: problemDetailVO.problemKeyword, with: " " + problemDetailVO.problemKeyword + " ")
+        var keywordDistinguished = problemDetailVO.problemAnswer.replacingOccurrences(of: keyword, with: " " + keyword + " ")
+        
         answerSplited = keywordDistinguished.split(separator: " ").map { String($0) }
+        for word in answerSplited {
+            if word == keyword {
+                keywordRange.append((0, keyword.count))
+            } else {
+                keywordRange.append((-1, -1))
+            }
+        }
+        
+        if keyword.count > keywordBoxMaxLength {
+            keywordDistinguished = keywordDistinguished.replacingOccurrences(of: keyword, with: keyword[0..<keywordBoxMaxLength] + " " + keyword[keywordBoxMaxLength..<keyword.count] )
+            
+            for idx in (0..<answerSplited.count).reversed() {
+                if keywordRange[idx].0 != -1 {
+                    keywordRange[idx] = (keywordBoxMaxLength, keyword.count)
+                    keywordRange.insert((0, keywordBoxMaxLength), at: idx)
+                }
+            }
+            
+            answerSplited = keywordDistinguished.split(separator: " ").map { String($0) }
+            
+            print(keywordRange)
+            print(answerSplited)
+        }
     }
 }


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 키워드 박스가 너무 길 때 화면 넘어가는 현상 해결
- [x] 최대길이 9개 박스로 해놓고 넘어가면 분리되서 아래에 나타나도록 함
- 18개가 넘어갈 경우는 따로 처리 X (필요하다면 추후 구현 가능) 

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|iPhone SE|iPhone SE|iPhone 14|iPhone 14|
|:---:|:---:|:---:|:---:|
|<img width="200" src="https://github.com/SWM14-Lito/lito-ios/assets/72330884/7514701e-da42-4f7a-b2eb-b870520cb0ba">|<img width="200" src="https://github.com/SWM14-Lito/lito-ios/assets/72330884/d72900c8-23a7-4f79-982b-d7771ad10524">|<img width="200" src="https://github.com/SWM14-Lito/lito-ios/assets/72330884/93219f66-4bcb-464d-be05-3a795388a565">|<img width="200" src="https://github.com/SWM14-Lito/lito-ios/assets/72330884/8071839e-9070-46c3-81de-e59343bfb6f3">|
